### PR TITLE
避難所情報を取得するスクリプトを追加

### DIFF
--- a/script/get-hinanjo.py
+++ b/script/get-hinanjo.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python
+# coding: utf-8
+
+import urllib.request
+from bs4 import BeautifulSoup
+
+def get_hinanjo_page(url):
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    html = urllib.request.urlopen(req).read()
+    soup = BeautifulSoup(html, "html.parser")
+    body = soup.find(id="wrap")
+    title = body.h2.text
+    print('---')
+    print('title:' + title)
+    print('---')
+    content = body.p.get_text()
+    print(content)
+
+
+def hinanjo():
+    url = 'http://ehime.force.com/PUB_VF_HinanjyoList'
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    html = urllib.request.urlopen(req).read()
+    soup = BeautifulSoup(html, "html.parser")
+    volunteer = soup.find_all("div", {"class": "volunteer"})[0]
+    dls = volunteer.find_all("dl")
+    dl = dls[0]
+    get_hinanjo_page('http://ehime.force.com/' + dl.a.get('href'))
+
+if __name__ == '__main__':
+    hinanjo()


### PR DESCRIPTION
#27 の対応で、
http://ehime.force.com/PUB_VF_HinanjyoList の一番上のページ(多分最新のページ)から避難所の情報を取得するスクリプトを作りました。
スクリプトの実行には  BeautifulSoupが必要です。

実行結果は以下のようになります。

```
---
title:[避難所情報]避難所情報(2018/07/25 12:24発表)
---
大洲市から以下のとおり発表されました。

大洲市 避難所情報 :2018年７月５日　大雨災害

補足情報:
避難所の開設・閉鎖状況を更新しました。

(避難世帯数、避難人数は、自主避難を含む)
グループホーム嶺南:臨時避難所 開設
　　(2018/07/10 9:00)
　　避難世帯数:1世帯
　　避難人数:1人
老人保健施設フレンド:臨時避難所 閉鎖
　　(2018/07/13 18:00)
　　避難世帯数:未入力
　　避難人数:未入力
特別養護老人ホーム希望ヶ丘荘:臨時避難所 開設
　　(2018/07/09 18:00)
　　避難世帯数:未入力
　　避難人数:2人
(以下略)

```

多分もう少しこうして欲しいと言った要望があると思うので、コメントください。
