### PR TITLE
カテゴリー/タグのリンクが向こうになっていたのを修正

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -223,10 +223,10 @@ whitelist:
 #  - <base_path/categories/my-awesome-category/index.html ~> path: /categories/
 #  - <base_path/my-awesome-category/index.html ~> path: /
 category_archive:
-  type: jekyll-archives
+  type: liquid
   path: /categories/
 tag_archive:
-  type: jekyll-archives
+  type: liquid
   path: /tags/
 
 # https://github.com/jekyll/jekyll-archives


### PR DESCRIPTION
/categories/:name  のページが404になっていた。

<img width="480" alt="2018-07-29 0 14 22" src="https://user-images.githubusercontent.com/459739/43357944-d672d68a-92c4-11e8-8588-e25a384362de.png">

categoryや tag は ページではなく、ハッシュではないといけないらしくうまく動かないので、
投稿ページの下にあるタグ/カテゴリーのリンク先を `categories/#ボランティア` になるように修正した