### PR TITLE
装備画像のリンク切れ修正

### DIFF
--- a/volunteer-new/preparation.md
+++ b/volunteer-new/preparation.md
@@ -18,7 +18,7 @@ header:
 
 - 熱中症対策
 
-![装備](/assets/volunteer-equipments.png)
+![装備](/assets/images/volunteer-equipments.png)
 
 ## 手続き
 


### PR DESCRIPTION
ボランティアの事前準備
https://cheerup-ehime.github.io/volunteer-new/preparation/
装備の画像がリンク切れになっていたので修正しました。